### PR TITLE
Update sprig version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Broadcom/gotpl-titans
 go 1.13
 
 require (
-	github.com/Broadcom/sprig v0.0.0-20231201064609-908436cae033
+	github.com/Broadcom/sprig v0.0.0-20240213172023-a8eb64fb17b2
 	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.4 // indirect
 	github.com/ghodss/yaml v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -39,8 +39,8 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/Broadcom/goregen v0.0.0-20231010211337-3eca76217ae8 h1:ZeQQMNloT7es1et7SCdrYPOmTcG+kp1FuEda5+0G0Uw=
 github.com/Broadcom/goregen v0.0.0-20231010211337-3eca76217ae8/go.mod h1:Eth6Ijai9+NpSVRe32WeWF2Zdg98ytYLMn4vBGJXezo=
-github.com/Broadcom/sprig v0.0.0-20231201064609-908436cae033 h1:6RLPqGxU1qL6k4ZxH78FD96xGit2OOswvp6WmDthoyo=
-github.com/Broadcom/sprig v0.0.0-20231201064609-908436cae033/go.mod h1:msDj0RqHs5lycK0ChiC/JBWgbP8VFogVaGJhOG3QZNI=
+github.com/Broadcom/sprig v0.0.0-20240213172023-a8eb64fb17b2 h1:Qkj/hI2ToNUTWHS3EF+qpXF2bORU2RiDIoi4VayChgI=
+github.com/Broadcom/sprig v0.0.0-20240213172023-a8eb64fb17b2/go.mod h1:msDj0RqHs5lycK0ChiC/JBWgbP8VFogVaGJhOG3QZNI=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=


### PR DESCRIPTION
the sprig was update on randFromString to use only lower case alphabetic chars in the generated random string to avoid http call failure with non-acceptable chars in the URL